### PR TITLE
fix: only run golangci-lint github action when .go files are changed

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - master
+    paths:
+      - '**/*.go'
 
 permissions:
   contents: read


### PR DESCRIPTION
Fix bug that only run golangci-lint github action when .go files are changed.